### PR TITLE
Samyuktha | MOBN-2523 | Update port forwarding of openmrs, mart & metabase db to take default value when env is not set.

### DIFF
--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     # As we require master slave setup on Prod, exposing the port by default and added env file path.
     env_file: ${OPENMRS_DB_ENV_PATH:-}
     ports:
-      - ${OPENMRS_DB_PORT:-3306}
+      - ${OPENMRS_DB_PORT:-3306}:3306
     volumes:
       - "${OPENMRS_DB_CNF_PATH}:/etc/mysql/conf.d/docker.cnf"
       - 'openmrsdbdata:/var/lib/mysql'
@@ -107,7 +107,7 @@ services:
     restart: always
     profiles: ["metabase", "bahmni-mart" ,"emr"]
     ports:
-      - ${METABASE_DB_PORT:-5432}
+      - ${METABASE_DB_PORT:-5432}:5432
     environment:
       TZ: ${TZ}
       POSTGRES_DB: ${METABASE_DB_NAME:?}
@@ -149,7 +149,7 @@ services:
     profiles: ["bahmni-mart" ,"emr"]
     restart: always
     ports:
-      - ${MART_DB_PORT:-5432}
+      - ${MART_DB_PORT:-5433}:5432
     environment:
       TZ: ${TZ}
       POSTGRES_DB: ${MART_DB_NAME:?}


### PR DESCRIPTION
https://msfprojects.atlassian.net/browse/MOBN-2523

**Reason for Change:**
Port forwarding for metabasedb was not working as expected with the existing syntax.

**Description of Change:**
1. Updated the port forwarding for openmrsdb, martdb & metabasedb services with default values added.

**Key Points for the Reviewer:**
<!-- Highlight any areas that require special attention during the review, such as complex logic, security implications, or dependencies on other parts of the codebase. -->

**Testing Details:**
<!-- Describe the testing approach and whatever testing was done as part of this PR with relevant details. -->
  - [ ] Unit Tests
  - [ ] Manual Testing (if applicable)

**Screenshots/Videos:**
<!-- Attach any relevant screenshots or videos demonstrating the changes made. Ensure that sensitive information is not exposed. -->
